### PR TITLE
[spinnaker] updates to invalid parameters for v2 events

### DIFF
--- a/docs/spinnaker.md
+++ b/docs/spinnaker.md
@@ -16,16 +16,16 @@ To add this stage to your environment, you'll need to:
 1. [Grab your effx API key](https://app.effx.com/account_settings)
 2. Replace your `EFFX_API_KEY` in the yaml snippet below and save it into your `orca-local.yaml` file. Replace the `DECK_HOSTNAME` with your Spinnaker URL.
 3. Deploy the configuration update.
-4. Use the new custom stage in the Spinnaker UI. Use the corresponding service name to link the event in Effx.
+4. Use the new custom stage in the Spinnaker UI. Use the corresponding service name to link the event in effx.
 
 ```yml
 ---
 webhook:
   preconfigured:
-    - label: 'Effx - Deployment Event'
+    - label: 'effx - deployment event'
       type: 'effxEvent'
       enabled: true
-      description: 'Post a Deployment Event to Effx'
+      description: 'Post a deployment event to effx'
       method: 'POST'
       customHeaders:
         X-Effx-Api-Key:
@@ -34,9 +34,9 @@ webhook:
           - 'application/json'
       url: 'https://api.effx.io/v2/events'
       payload: '{
-        "name": "Spinnaker - Webhook Stage",
-        "description": "${execution.getName()} triggered by ${trigger.user} (${trigger.type})",
-        "produced_at_time_milliseconds": ${execution.getBuildTime()},
+        "title": "Spinnaker - Webhook Stage",
+        "message": "${execution.getName()} triggered by ${trigger.user} (${trigger.type})",
+        "timestamp_milliseconds": ${execution.getBuildTime()},
         "actions": [
           {
             "level": "info",
@@ -44,15 +44,20 @@ webhook:
             "url": "https://<DECK_HOSTNAME>/#/applications/${execution.getApplication()}/executions/${execution.getId()}"
           }
         ],
+        "tags": [
+          {
+            "key": "type",
+            "value": "deploy"
+          }
+        ],
         "integration": {
           "name": "spinnaker"
         },
-        "service": {
-          "name": "${parameterValues["service"]}"
+        "service_name": "${parameterValues["service"]}"
         }
       }'
       parameters:
-        - label: 'Effx Service'
+        - label: 'effx Service'
           name: 'service'
-          description: 'The Effx Service for this Event'
+          description: 'The effx service for this event'
 ```


### PR DESCRIPTION
Fixes incorrect parameters for `v2/events` as instructions were using old `v1/events` parameters like `name` and `description`